### PR TITLE
Remove harmful $! forcing in beside

### DIFF
--- a/pretty.cabal
+++ b/pretty.cabal
@@ -62,6 +62,7 @@ Test-Suite test-pretty
         UnitLargeDoc
         UnitPP1
         UnitT3911
+        UnitT32
     extensions: CPP, BangPatterns, DeriveGeneric
     include-dirs: src/Text/PrettyPrint/Annotated
     ghc-options: -rtsopts -with-rtsopts=-K2M

--- a/src/Text/PrettyPrint/Annotated/HughesPJ.hs
+++ b/src/Text/PrettyPrint/Annotated/HughesPJ.hs
@@ -695,7 +695,7 @@ beside p@(Beside p1 g1 q1) g2 q2
          | otherwise             = beside (reduceDoc p) g2 q2
 beside p@(Above{})         g q   = let !d = reduceDoc p in beside d g q
 beside (NilAbove p)        g q   = nilAbove_ $! beside p g q
-beside (TextBeside t p)    g q   = TextBeside t $! rest
+beside (TextBeside t p)    g q   = TextBeside t rest
                                where
                                   rest = case p of
                                            Empty -> nilBeside g q

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -18,6 +18,7 @@ import TestStructures
 import UnitLargeDoc
 import UnitPP1
 import UnitT3911
+import UnitT32
 
 import Control.Monad
 import Data.Char (isSpace)
@@ -39,6 +40,7 @@ main = do
     -- unit tests
     testPP1
     testT3911
+    testT32
     testLargeDoc
 
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/UnitT32.hs
+++ b/tests/UnitT32.hs
@@ -1,0 +1,9 @@
+-- Test from https://github.com/haskell/pretty/issues/32#issuecomment-223073337
+module UnitT32 where
+
+import Text.PrettyPrint.HughesPJ
+
+import TestUtils
+
+testT32 :: IO ()
+testT32 = simpleMatch "T3911" (replicate 10 'x') $ take 10 $ render $ hcat $ repeat $ text "x"


### PR DESCRIPTION
This addresses some of #32, and adds a new test case. With the fix the test completes successfully. Without the fix I see:

```
Stack space overflow: current size 99200 bytes.
Use `+RTS -Ksize -RTS' to increase it.
```

Before the fix there is no amount of memory that would allow the test to complete - it's essentially a memory-allocating loop.