### PR TITLE
Add functions for coverting between annotated and unannotated Docs.

### DIFF
--- a/src/Text/PrettyPrint.hs
+++ b/src/Text/PrettyPrint.hs
@@ -26,6 +26,9 @@ module Text.PrettyPrint (
         -- * The document type
         Doc,
 
+        -- ** Converting to an annotated Doc
+        docToUnitDoc,
+
         -- * Constructing documents
 
         -- ** Converting values into documents

--- a/src/Text/PrettyPrint/Annotated.hs
+++ b/src/Text/PrettyPrint/Annotated.hs
@@ -26,6 +26,9 @@ module Text.PrettyPrint.Annotated (
         -- * The document type
         Doc,
 
+        -- ** Convert unit-annotated Doc to an arbitrary annotation type
+        unitDocToAnnotatedDoc,
+
         -- * Constructing documents
 
         -- ** Converting values into documents

--- a/src/Text/PrettyPrint/Annotated/HughesPJ.hs
+++ b/src/Text/PrettyPrint/Annotated/HughesPJ.hs
@@ -27,6 +27,9 @@ module Text.PrettyPrint.Annotated.HughesPJ (
         -- * The document type
         Doc, TextDetails(..), AnnotDetails(..),
 
+        -- ** Convert unit-annotated Doc to an arbitrary annotation type
+        unitDocToAnnotatedDoc,
+
         -- * Constructing documents
 
         -- ** Converting values into documents
@@ -1192,3 +1195,27 @@ renderDecoratedM startAnn endAnn txt docEnd =
       PStr s -> (txt s   >> rest, stack)
 
   finalize (m,_) = m
+
+-- | Accepte a document with unit annotations and convert it to a document
+-- of an arbitrary annotated type.  Removes any existing annotations.
+unitDocToAnnotatedDoc :: Doc () -> Doc a
+unitDocToAnnotatedDoc (TextBeside AnnotStart d)
+  = unitDocToAnnotatedDoc d
+unitDocToAnnotatedDoc (TextBeside (AnnotEnd _) d)
+  = unitDocToAnnotatedDoc d
+unitDocToAnnotatedDoc (TextBeside (NoAnnot td n) d)
+  = TextBeside (NoAnnot td n) $ unitDocToAnnotatedDoc d
+unitDocToAnnotatedDoc Empty
+  = Empty
+unitDocToAnnotatedDoc NoDoc
+  = NoDoc
+unitDocToAnnotatedDoc (Nest i d)
+  = Nest i $ unitDocToAnnotatedDoc d
+unitDocToAnnotatedDoc (NilAbove d)
+  = NilAbove $ unitDocToAnnotatedDoc d
+unitDocToAnnotatedDoc (Union a b)
+  = Union (unitDocToAnnotatedDoc a) (unitDocToAnnotatedDoc b)
+unitDocToAnnotatedDoc (Beside a f b)
+  = Beside (unitDocToAnnotatedDoc a) f (unitDocToAnnotatedDoc b)
+unitDocToAnnotatedDoc (Above a f b)
+  = Above (unitDocToAnnotatedDoc a) f (unitDocToAnnotatedDoc b)

--- a/src/Text/PrettyPrint/HughesPJ.hs
+++ b/src/Text/PrettyPrint/HughesPJ.hs
@@ -34,6 +34,9 @@ module Text.PrettyPrint.HughesPJ (
         -- * The document type
         Doc, TextDetails(..),
 
+        -- ** Converting to an annotated Doc
+        docToUnitDoc,
+
         -- * Constructing documents
 
         -- ** Converting values into documents
@@ -454,4 +457,8 @@ fullRender :: Mode                     -- ^ Rendering mode.
 fullRender m lineLen ribbons txt rest (Doc doc)
   = Ann.fullRender m lineLen ribbons txt rest doc
 {-# INLINE fullRender #-}
+
+-- | Convert an unannotated 'Doc' to a unit-annotated @Ann.Doc ()@.
+docToUnitDoc :: Doc -> Ann.Doc ()
+docToUnitDoc (Doc ad) = ad
 


### PR DESCRIPTION
- `docToUnitDoc :: Doc -> Ann.Doc ()`
- `unitDocToAnnotatedDoc :: Ann.Doc () -> Ann.Doc a`

These two functions together allow you to embed a unannotated `Doc`
inside another, annotated `Doc a` of arbitrary annotation type.