### PR TITLE
Make CI work again (GHC 8.0 - 9.12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+# Andreas, 2025-07-26, hand-knitted CI using Cabal
+
 name: Cabal CI
 on:
   push:
@@ -14,7 +16,27 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ghc: ['9.12']
+        ghc:
+        # - '9.12'  # currently subsumed by latest
+          - '9.10'
+          - '9.8'
+          - '9.6'
+        # - '9.4'   # skip intermediate ghc version
+        # - '9.2'   # skip intermediate ghc version
+        # - '9.0'   # skip intermediate ghc version
+        # - '8.10'  # skip intermediate ghc version
+        # - '8.8'   # skip intermediate ghc version
+        # - '8.6'   # skip intermediate ghc version
+        # - '8.4'   # skip intermediate ghc version
+        # - '8.2'   # skip intermediate ghc version
+          - '8.0'
+        include:
+         - os: ubuntu-latest
+           ghc: latest
+         - os: macos-latest
+           ghc: latest
+         - os: windows-latest
+           ghc: latest
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: Cabal CI
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: ${{ matrix.os }} GHC ${{ matrix.ghc }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        ghc: ['9.12']
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: haskell-actions/setup@v2
+      id: setup
+      with:
+        ghc-version: ${{ matrix.ghc }}
+
+    - name: Restore cache
+      uses: actions/cache/restore@v4
+      id: cache
+      with:
+        path: ${{ steps.setup.outputs.cabal-store }}
+        key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}-sha-${{ github.sha }}
+
+    - run: cabal build --dependencies-only
+    - run: cabal build
+    - run: cabal build --enable-tests
+    - run: cabal test
+    - run: cabal build --enable-tests --enable-benchmarks
+    - run: cabal bench
+
+    - name: Save cache
+      uses: actions/cache/save@v4
+      if: always()
+      with:
+        path: ${{ steps.setup.outputs.cabal-store }}
+        key:  ${{ steps.cache.outputs.cache-primary-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,14 @@ jobs:
 
     - run: cabal build --dependencies-only
     - run: cabal build
-    - run: cabal build --enable-tests
-    - run: cabal test
-    - run: cabal build --enable-tests --enable-benchmarks
-    - run: cabal bench
+
+    # Cannot build the testsuite because template-haskell depends on pretty
+    # and containers and QuickCheck depend on template-haskell.
+    # See also https://github.com/haskell/containers/issues/1156
+    # - run: cabal build -c 'QuickCheck -templatehaskell' --enable-tests
+    # - run: cabal test  -c 'QuickCheck -templatehaskell' --enable-tests
+    # - run: cabal build -c 'QuickCheck -templatehaskell' --enable-tests --enable-benchmarks
+    # - run: cabal bench -c 'QuickCheck -templatehaskell' --enable-tests --enable-benchmarks
 
     - name: Save cache
       uses: actions/cache/save@v4

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -215,7 +215,7 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
-          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(pretty)$/; }' >> cabal.project.local
+          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(pretty|template-haskell)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
       - name: dump install plan

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -134,7 +134,7 @@ jobs:
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
-          echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
+          echo "ARG_TESTS=--disable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--disable-benchmarks" >> "$GITHUB_ENV"
           echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
@@ -214,8 +214,9 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package pretty" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
+          constraints: QuickCheck -templatehaskell
           EOF
-          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(pretty|template-haskell)$/; }' >> cabal.project.local
+          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(pretty)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
       - name: dump install plan
@@ -238,9 +239,6 @@ jobs:
       - name: build
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
-      - name: tests
-        run: |
-          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
       - name: cabal check
         run: |
           cd ${PKGDIR_pretty} || false

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.11.20210220
+# version: 0.19.20250506
 #
-# REGENDATA ("0.11.20210220",["github","cabal.project"])
+# REGENDATA ("0.19.20250506",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -22,67 +22,126 @@ on:
       - master
 jobs:
   linux:
-    name: Haskell-CI - Linux - GHC ${{ matrix.ghc }}
-    runs-on: ubuntu-18.04
+    name: Haskell-CI - Linux - ${{ matrix.compiler }}
+    runs-on: ubuntu-24.04
+    timeout-minutes:
+      60
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:jammy
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - ghc: 9.0.1
+          - compiler: ghc-9.12.2
+            compilerKind: ghc
+            compilerVersion: 9.12.2
+            setup-method: ghcup
             allow-failure: false
-          - ghc: 8.10.3
+          - compiler: ghc-9.10.2
+            compilerKind: ghc
+            compilerVersion: 9.10.2
+            setup-method: ghcup
             allow-failure: false
-          - ghc: 8.8.4
+          - compiler: ghc-9.8.4
+            compilerKind: ghc
+            compilerVersion: 9.8.4
+            setup-method: ghcup
             allow-failure: false
-          - ghc: 8.6.5
+          - compiler: ghc-9.6.7
+            compilerKind: ghc
+            compilerVersion: 9.6.7
+            setup-method: ghcup
             allow-failure: false
-          - ghc: 8.4.4
+          - compiler: ghc-9.4.8
+            compilerKind: ghc
+            compilerVersion: 9.4.8
+            setup-method: ghcup
             allow-failure: false
-          - ghc: 8.2.2
+          - compiler: ghc-9.2.8
+            compilerKind: ghc
+            compilerVersion: 9.2.8
+            setup-method: ghcup
             allow-failure: false
-          - ghc: 8.0.2
+          - compiler: ghc-9.0.2
+            compilerKind: ghc
+            compilerVersion: 9.0.2
+            setup-method: ghcup
             allow-failure: false
-          - ghc: 7.10.3
+          - compiler: ghc-8.10.7
+            compilerKind: ghc
+            compilerVersion: 8.10.7
+            setup-method: ghcup
             allow-failure: false
-          - ghc: 7.8.4
+          - compiler: ghc-8.8.4
+            compilerKind: ghc
+            compilerVersion: 8.8.4
+            setup-method: ghcup
             allow-failure: false
-          - ghc: 7.6.3
+          - compiler: ghc-8.6.5
+            compilerKind: ghc
+            compilerVersion: 8.6.5
+            setup-method: ghcup
             allow-failure: false
-          - ghc: 7.4.2
+          - compiler: ghc-8.4.4
+            compilerKind: ghc
+            compilerVersion: 8.4.4
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-8.2.2
+            compilerKind: ghc
+            compilerVersion: 8.2.2
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-8.0.2
+            compilerKind: ghc
+            compilerVersion: 8.0.2
+            setup-method: ghcup
             allow-failure: false
       fail-fast: false
     steps:
-      - name: apt
+      - name: apt-get install
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common
-          apt-add-repository -y 'ppa:hvr/ghc'
-          apt-get update
-          apt-get install -y ghc-$GHC_VERSION cabal-install-3.4
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
+      - name: Install GHCup
+        run: |
+          mkdir -p "$HOME/.ghcup/bin"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.50.1/x86_64-linux-ghcup-0.1.50.1 > "$HOME/.ghcup/bin/ghcup"
+          chmod a+x "$HOME/.ghcup/bin/ghcup"
+      - name: Install cabal-install
+        run: |
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+      - name: Install GHC (GHCup)
+        if: matrix.setup-method == 'ghcup'
+        run: |
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
         env:
-          GHC_VERSION: ${{ matrix.ghc }}
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: Set PATH and environment variables
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-          echo "LANG=C.UTF-8" >> $GITHUB_ENV
-          echo "CABAL_DIR=$HOME/.cabal" >> $GITHUB_ENV
-          echo "CABAL_CONFIG=$HOME/.cabal/config" >> $GITHUB_ENV
-          HC=/opt/ghc/$GHC_VERSION/bin/ghc
-          echo "HC=$HC" >> $GITHUB_ENV
-          echo "HCPKG=/opt/ghc/$GHC_VERSION/bin/ghc-pkg" >> $GITHUB_ENV
-          echo "HADDOCK=/opt/ghc/$GHC_VERSION/bin/haddock" >> $GITHUB_ENV
-          echo "CABAL=/opt/cabal/3.4/bin/cabal -vnormal+nowrap" >> $GITHUB_ENV
+          echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
+          echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
+          echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
-          echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
-          echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
-          echo "ARG_BENCH=--disable-benchmarks" >> $GITHUB_ENV
-          echo "HEADHACKAGE=false" >> $GITHUB_ENV
-          echo "ARG_COMPILER=--ghc --with-compiler=$HC" >> $GITHUB_ENV
-          echo "GHCJSARITH=0" >> $GITHUB_ENV
+          echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
+          echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
+          echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
-          GHC_VERSION: ${{ matrix.ghc }}
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: env
         run: |
           env
@@ -105,6 +164,10 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          cat >> $CABAL_CONFIG <<EOF
+          program-default-options
+            ghc-options: $GHCJOBS +RTS -M3G -RTS
+          EOF
           cat $CABAL_CONFIG
       - name: versions
         run: |
@@ -117,14 +180,14 @@ jobs:
       - name: install cabal-plan
         run: |
           mkdir -p $HOME/.cabal/bin
-          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
-          echo 'de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz' | sha256sum -c -
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.7.3.0/cabal-plan-0.7.3.0-x86_64-linux.xz > cabal-plan.xz
+          echo 'f62ccb2971567a5f638f2005ad3173dba14693a45154c1508645c52289714cb2  cabal-plan.xz' | sha256sum -c -
           xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -143,7 +206,8 @@ jobs:
       - name: generate cabal.project
         run: |
           PKGDIR_pretty="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/pretty-[0-9.]*')"
-          echo "PKGDIR_pretty=${PKGDIR_pretty}" >> $GITHUB_ENV
+          echo "PKGDIR_pretty=${PKGDIR_pretty}" >> "$GITHUB_ENV"
+          rm -f cabal.project cabal.project.local
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_pretty}" >> cabal.project
@@ -151,19 +215,19 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
-          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(pretty)$/; }' >> cabal.project.local
+          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(pretty)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
       - name: dump install plan
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
-      - name: cache
-        uses: actions/cache@v2
+      - name: restore cache
+        uses: actions/cache/restore@v4
         with:
-          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ github.sha }}
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
-          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
+          restore-keys: ${{ runner.os }}-${{ matrix.compiler }}-
       - name: install dependencies
         run: |
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --dependencies-only -j2 all
@@ -183,8 +247,14 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+      - name: save cache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
+          path: ~/.cabal/store

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -135,7 +135,7 @@ jobs:
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
-          echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
+          echo "ARG_BENCH=--disable-benchmarks" >> "$GITHUB_ENV"
           echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 dist/
+dist-newstyle/
 GNUmakefile
 dist-install
 ghc.mk
 cabal.sandbox.config
-.cabal-sandbox
-.stack-work
+.cabal-sandbox/
+.stack-work/
+*~

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,2 +1,2 @@
 branches: master
-benchmarks: False
+-- benchmarks: False

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,3 +1,3 @@
 branches: master
-installed: +all -pretty
+installed: +all -pretty -template-haskell
 benchmarks: False

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,2 +1,3 @@
 branches: master
--- benchmarks: False
+installed: +all -pretty
+benchmarks: False

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,3 +1,6 @@
 branches: master
-installed: +all -pretty -template-haskell
+installed: +all -pretty
+-- Tests and benchmarks do not build due to cycling package dependencies.
+-- QuickCheck/containers -> template-haskell -> pretty.
 benchmarks: False
+tests: False

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,7 @@
 packages: .
+
+constraints: QuickCheck -templatehaskell
+
+-- If we could get rid of template-haskell we could build the testsuite.
+-- https://github.com/haskell/containers/issues/1156
+-- constraints: containers -templatehaskell

--- a/pretty.cabal
+++ b/pretty.cabal
@@ -60,7 +60,7 @@ Library
       build-depends: ghc-prim
 
     default-language: Haskell98
-    extensions: CPP, BangPatterns, DeriveGeneric
+    default-extensions: CPP, BangPatterns, DeriveGeneric
     ghc-options: -Wall -fwarn-tabs
 
 Test-Suite test-pretty
@@ -87,7 +87,7 @@ Test-Suite test-pretty
                    QuickCheck >= 2.5 && <3
 
     default-language: Haskell98
-    extensions: CPP, BangPatterns, DeriveGeneric
+    default-extensions: CPP, BangPatterns, DeriveGeneric
     ghc-options: -rtsopts -with-rtsopts=-K2M
 
 benchmark pretty-bench
@@ -99,6 +99,7 @@ benchmark pretty-bench
                , criterion
                , pretty
 
+  default-language: Haskell98
   ghc-options:
     -Wall
     -fwarn-tabs

--- a/pretty.cabal
+++ b/pretty.cabal
@@ -1,3 +1,4 @@
+cabal-version: 1.18
 name:          pretty
 version:       1.1.3.6
 synopsis:      Pretty-printing library
@@ -7,35 +8,41 @@ description:
         format of your choosing. This is useful for compilers and related
         tools.
         .
-        This library was originally designed by John Hughes's and has since
+        This library was originally designed by John Hughes and has since
         been heavily modified by Simon Peyton Jones.
 
 license:       BSD3
 license-file:  LICENSE
 category:      Text
 maintainer:    David Terei <code@davidterei.com>
-homepage:      http://github.com/haskell/pretty
-bug-reports:   http://github.com/haskell/pretty/issues
+homepage:      https://github.com/haskell/pretty
+bug-reports:   https://github.com/haskell/pretty/issues
 stability:     Stable
 build-type:    Simple
-Extra-Source-Files: README.md CHANGELOG.md
-Cabal-Version: >= 1.8
-Tested-with:
-  GHC ==7.4.2
-   || ==7.6.3
-   || ==7.8.4
-   || ==7.10.3
-   || ==8.0.2
-   || ==8.2.2
-   || ==8.4.4
-   || ==8.6.5
-   || ==8.8.4
-   || ==8.10.3
-   || ==9.0.1
+
+-- extra-doc-files supported since cabal-version 1.18
+extra-doc-files:
+  README.md
+  CHANGELOG.md
+
+tested-with:
+  GHC == 9.12.2
+  GHC == 9.10.2
+  GHC == 9.8.4
+  GHC == 9.6.7
+  GHC == 9.4.8
+  GHC == 9.2.8
+  GHC == 9.0.2
+  GHC == 8.10.7
+  GHC == 8.8.4
+  GHC == 8.6.5
+  GHC == 8.4.4
+  GHC == 8.2.2
+  GHC == 8.0.2
 
 source-repository head
     type:     git
-    location: http://github.com/haskell/pretty.git
+    location: https://github.com/haskell/pretty.git
 
 Library
     hs-source-dirs: src
@@ -46,22 +53,22 @@ Library
         Text.PrettyPrint.Annotated
         Text.PrettyPrint.Annotated.HughesPJ
         Text.PrettyPrint.Annotated.HughesPJClass
+
     build-depends: base >= 4.5 && < 5,
                    deepseq >= 1.1
     if impl(ghc)
       build-depends: ghc-prim
+
+    default-language: Haskell98
     extensions: CPP, BangPatterns, DeriveGeneric
     ghc-options: -Wall -fwarn-tabs
 
 Test-Suite test-pretty
     type: exitcode-stdio-1.0
+    main-is: Test.hs
     hs-source-dirs: tests
                     src
-    build-depends: base >= 4.5 && < 5,
-                   deepseq >= 1.1,
-                   ghc-prim,
-                   QuickCheck >= 2.5 && <3
-    main-is: Test.hs
+    include-dirs: src/Text/PrettyPrint/Annotated
     other-modules:
         Text.PrettyPrint.Annotated.HughesPJ
         Text.PrettyPrint.HughesPJ
@@ -73,15 +80,33 @@ Test-Suite test-pretty
         UnitPP1
         UnitT3911
         UnitT32
+
+    build-depends: base >= 4.5 && < 5,
+                   deepseq >= 1.1,
+                   ghc-prim,
+                   QuickCheck >= 2.5 && <3
+
+    default-language: Haskell98
     extensions: CPP, BangPatterns, DeriveGeneric
-    include-dirs: src/Text/PrettyPrint/Annotated
     ghc-options: -rtsopts -with-rtsopts=-K2M
 
 benchmark pretty-bench
   type: exitcode-stdio-1.0
   main-is: Bench.hs
   hs-source-dirs: bench
-  ghc-options: -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -O2 -threaded -rtsopts -with-rtsopts=-N1 -with-rtsopts=-s -with-rtsopts=-qg
+
   build-depends: base >= 4.5 && < 5
                , criterion
                , pretty
+
+  ghc-options:
+    -Wall
+    -fwarn-tabs
+    -fwarn-incomplete-uni-patterns
+    -fwarn-incomplete-record-updates
+    -O2
+    -threaded
+    -rtsopts
+    -with-rtsopts=-N1
+    -with-rtsopts=-s
+    -with-rtsopts=-qg


### PR DESCRIPTION
This PR fixes the Haskell CI and adds another CI using Cabal that also runs on macOS and Windows.

Unfortunately, the tests and benchmarks cannot be built and run:
- #68

While updating the `tested-with` field in `pretty.cabal`, I included some cosmetic fixes, such as raising the `cabal-version` to a more reasonable value.
