### PR TITLE
Remove unused `ghc-prim` dependency

### DIFF
--- a/pretty.cabal
+++ b/pretty.cabal
@@ -56,8 +56,6 @@ Library
 
     build-depends: base >= 4.5 && < 5,
                    deepseq >= 1.1
-    if impl(ghc)
-      build-depends: ghc-prim
 
     default-language: Haskell98
     default-extensions: CPP, BangPatterns, DeriveGeneric
@@ -83,7 +81,6 @@ Test-Suite test-pretty
 
     build-depends: base >= 4.5 && < 5,
                    deepseq >= 1.1,
-                   ghc-prim,
                    QuickCheck >= 2.5 && <3
 
     default-language: Haskell98

--- a/pretty.cabal
+++ b/pretty.cabal
@@ -54,7 +54,7 @@ Library
         Text.PrettyPrint.Annotated.HughesPJ
         Text.PrettyPrint.Annotated.HughesPJClass
 
-    build-depends: base >= 4.5 && < 5,
+    build-depends: base >= 4.6 && < 5,
                    deepseq >= 1.1
 
     default-language: Haskell98
@@ -79,7 +79,7 @@ Test-Suite test-pretty
         UnitT3911
         UnitT32
 
-    build-depends: base >= 4.5 && < 5,
+    build-depends: base >= 4.6 && < 5,
                    deepseq >= 1.1,
                    QuickCheck >= 2.5 && <3
 
@@ -92,7 +92,7 @@ benchmark pretty-bench
   main-is: Bench.hs
   hs-source-dirs: bench
 
-  build-depends: base >= 4.5 && < 5
+  build-depends: base >= 4.6 && < 5
                , criterion
                , pretty
 

--- a/src/Text/PrettyPrint/Annotated/HughesPJ.hs
+++ b/src/Text/PrettyPrint/Annotated/HughesPJ.hs
@@ -195,9 +195,7 @@ data Doc a
   | NoDoc                                            -- ^ The empty set of documents.
   | Beside (Doc a) Bool (Doc a)                      -- ^ True <=> space between.
   | Above (Doc a) Bool (Doc a)                       -- ^ True <=> never overlap.
-#if __GLASGOW_HASKELL__ >= 701
   deriving (Generic)
-#endif
 
 {-
 Here are the invariants:
@@ -261,9 +259,7 @@ data TextDetails = Chr  {-# UNPACK #-} !Char -- ^ A single Char fragment
                  | PStr String -- ^ Used to represent a Fast String fragment
                                --   but now deprecated and identical to the
                                --   Str constructor.
-#if __GLASGOW_HASKELL__ >= 701 || __MHS__
                  deriving (Show, Eq, Generic)
-#endif
 
 -- Combining @Doc@ values
 #if __GLASGOW_HASKELL__ >= 800 || __MHS__
@@ -931,9 +927,7 @@ data Style
             -- 50 characters of ribbon to be displayed on a line, while
             -- allowing it to be indented up to 50 characters.
           }
-#if __GLASGOW_HASKELL__ >= 701
   deriving (Show, Eq, Generic)
-#endif
 
 -- | The default style (@mode=PageMode, lineLength=100, ribbonsPerLine=1.5@).
 style :: Style
@@ -952,9 +946,7 @@ data Mode = PageMode
           | OneLineMode
             -- ^ All on one line, 'lineLength' ignored and explicit new lines
             -- (@$$@) are turned into spaces.
-#if __GLASGOW_HASKELL__ >= 701 || __MHS__
           deriving (Show, Eq, Generic)
-#endif
 
 -- | Render the @Doc@ to a String using the default @Style@ (see 'style').
 render :: Doc a -> String

--- a/src/Text/PrettyPrint/HughesPJ.hs
+++ b/src/Text/PrettyPrint/HughesPJ.hs
@@ -115,9 +115,7 @@ infixl 5 $$, $+$
 -- | The abstract type of documents. A Doc represents a /set/ of layouts. A
 -- Doc with no occurrences of Union or NoDoc represents just one layout.
 newtype Doc = Doc (Ann.Doc ())
-#if __GLASGOW_HASKELL__ >= 701
                     deriving (Generic)
-#endif
 
 liftList :: ([Ann.Doc ()] -> Ann.Doc ()) -> ([Doc] -> Doc)
 liftList f ds = Doc (f [ d | Doc d <- ds ])


### PR DESCRIPTION
It seems `ghc-prim` was needed for `GHC.Generics` in `base-4.5` (I'm not 100% certain though, there is no version of `ghc-prim` with `GHC.Generics` on Hackage), so I bumped `base` to `>= 4.6`. Also get rid of `#if __GLASGOW_HASKELL__ >= 701`, since the minimum supported GHC version is 7.6 (after this change).